### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/near/near-token-rs/compare/v0.1.0...v0.2.0) - 2023-10-28
+
+### Other
+- [**breaking**] Renamed NearTokenError variants and implemented std::error::Error and Display traits for it ([#8](https://github.com/near/near-token-rs/pull/8))
+- Added more examples to `README.md` ([#6](https://github.com/near/near-token-rs/pull/6))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-token"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Serhieiev Ivan <serhieievivan6@gmail.com>", "Vlad Frolov <frolvlad@gmail.com>"]
 repository = "https://github.com/near/near-token"


### PR DESCRIPTION
## 🤖 New release
* `near-token`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `near-token` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.0/src/lints/enum_variant_added.ron

Failed in:
  variant NearTokenError:InvalidTokensAmount in /tmp/.tmpX43I2R/near-token-rs/src/error.rs:3
  variant NearTokenError:InvalidTokenUnit in /tmp/.tmpX43I2R/near-token-rs/src/error.rs:4

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.0/src/lints/enum_variant_missing.ron

Failed in:
  variant NearTokenError::IncorrectNumber, previously in file /tmp/.tmpycElJ7/near-token/src/error.rs:3
  variant NearTokenError::IncorrectUnit, previously in file /tmp/.tmpycElJ7/near-token/src/error.rs:4
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/near/near-token-rs/compare/v0.1.0...v0.2.0) - 2023-10-28

### Other
- [**breaking**] Renamed NearTokenError variants and implemented std::error::Error and Display traits for it ([#8](https://github.com/near/near-token-rs/pull/8))
- Added more examples to `README.md` ([#6](https://github.com/near/near-token-rs/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).