### PR TITLE
refactor!: Renamed NearTokenError variants and implemented std::error::Error and Display traits for it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,65 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NearTokenError {
-    IncorrectNumber(crate::utils::DecimalNumberParsingError),
-    IncorrectUnit(String),
+    InvalidTokensAmount(crate::utils::DecimalNumberParsingError),
+    InvalidTokenUnit(String),
+}
+
+impl std::fmt::Display for NearTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NearTokenError::InvalidTokensAmount(err) => write!(f, "invalid tokens amount: {}", err),
+            NearTokenError::InvalidTokenUnit(unit) => write!(f, "invalid token unit: {}", unit),
+        }
+    }
+}
+
+impl std::error::Error for NearTokenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            NearTokenError::InvalidTokensAmount(err) => Some(err),
+            NearTokenError::InvalidTokenUnit(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_near_token_error_display() {
+        assert_eq!(
+            format!(
+                "{}",
+                NearTokenError::InvalidTokensAmount(
+                    crate::utils::DecimalNumberParsingError::InvalidNumber("abc".to_owned())
+                )
+            ),
+            "invalid tokens amount: invalid number: abc"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                NearTokenError::InvalidTokensAmount(
+                    crate::utils::DecimalNumberParsingError::LongWhole("999999999999.0".to_owned())
+                )
+            ),
+            "invalid tokens amount: too long whole part: 999999999999.0"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                NearTokenError::InvalidTokensAmount(
+                    crate::utils::DecimalNumberParsingError::LongFractional(
+                        "0.999999999999".to_owned()
+                    )
+                )
+            ),
+            "invalid tokens amount: too long fractional part: 0.999999999999"
+        );
+        assert_eq!(
+            format!("{}", NearTokenError::InvalidTokenUnit("abc".to_owned())),
+            "invalid token unit: abc"
+        );
+    }
 }

--- a/src/trait_impls/display.rs
+++ b/src/trait_impls/display.rs
@@ -1,4 +1,4 @@
-use crate::{NearToken, NearTokenError, ONE_MILLINEAR};
+use crate::{NearToken, ONE_MILLINEAR};
 
 /// NearToken Display implementation rounds up the token amount to the relevant precision point.
 /// There are 4 breakpoints:
@@ -25,15 +25,6 @@ impl std::fmt::Display for NearToken {
                 near_rounded_up / 100,
                 near_rounded_up % 100
             )
-        }
-    }
-}
-
-impl std::fmt::Display for NearTokenError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NearTokenError::IncorrectNumber(err) => write!(f, "Incorrect number: {:?}", err),
-            NearTokenError::IncorrectUnit(err) => write!(f, "Incorrect unit: {}", err),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,31 +55,19 @@ pub enum DecimalNumberParsingError {
     LongFractional(String),
 }
 
-impl std::error::Error for DecimalNumberParsingError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        self.source()
-    }
-}
+impl std::error::Error for DecimalNumberParsingError {}
 
 impl std::fmt::Display for DecimalNumberParsingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DecimalNumberParsingError::InvalidNumber(s) => {
-                write!(f, "Invalid number: {}", s)
+                write!(f, "invalid number: {}", s)
             }
             DecimalNumberParsingError::LongWhole(s) => {
-                write!(f, "Long whole part: {}", s)
+                write!(f, "too long whole part: {}", s)
             }
             DecimalNumberParsingError::LongFractional(s) => {
-                write!(f, "Long fractional part: {}", s)
+                write!(f, "too long fractional part: {}", s)
             }
         }
     }


### PR DESCRIPTION
Missing `std::error::Error` implementation on `NearTokenError` prevents the use of NearToken type with `clap`, and potentially some other places.