### PR TITLE
1160: add exact amount display method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,34 @@ impl NearToken {
         }
         NearToken::from_yoctonear(self.as_yoctonear().saturating_div(rhs))
     }
+
+    /// Formats the `NearToken` and displays the amount in NEAR or yoctoNEAR depending on the value.
+    ///
+    /// # Examples
+    /// ```
+    /// use near_token::NearToken;
+    /// assert_eq!(NearToken::from_yoctonear(10_u128.pow(24)).exact_amount_display(), "1 NEAR");
+    /// assert_eq!(NearToken::from_yoctonear(15 * 10_u128.pow(23)).exact_amount_display(), "1.5 NEAR");
+    /// assert_eq!(NearToken::from_yoctonear(500).exact_amount_display(), "500 yoctoNEAR");
+    /// assert_eq!(NearToken::from_yoctonear(0).exact_amount_display(), "0 NEAR");
+    /// ```
+    pub fn exact_amount_display(&self) -> String {
+        let yoctonear = self.as_yoctonear();
+
+        if yoctonear == 0 {
+            "0 NEAR".to_string()
+        } else if yoctonear <= 1_000 {
+            format!("{} yoctoNEAR", yoctonear)
+        } else if yoctonear % ONE_NEAR == 0 {
+            format!("{} NEAR", yoctonear / ONE_NEAR)
+        } else {
+            format!(
+                "{}.{} NEAR",
+                yoctonear / ONE_NEAR,
+                format!("{:0>24}", yoctonear % ONE_NEAR).trim_end_matches('0')
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -340,5 +368,23 @@ mod test {
             tokens.saturating_div(another_tokens),
             NearToken::from_yoctonear(0)
         );
+    }
+
+    #[test]
+    fn exact_amount_display_tokens() {
+        let token = NearToken::from_yoctonear(0);
+        assert_eq!(token.exact_amount_display(), "0 NEAR");
+
+        let token = NearToken::from_yoctonear(500);
+        assert_eq!(token.exact_amount_display(), "500 yoctoNEAR");
+
+        let token = NearToken::from_yoctonear(10_u128.pow(24));
+        assert_eq!(token.exact_amount_display(), "1 NEAR");
+
+        let token = NearToken::from_yoctonear(15 * 10_u128.pow(23));
+        assert_eq!(token.exact_amount_display(), "1.5 NEAR");
+
+        let token = NearToken::from_yoctonear(1_234_567_890_123_456_789_000_000);
+        assert_eq!(token.exact_amount_display(), "1.234567890123456789 NEAR");
     }
 }


### PR DESCRIPTION
### Description 

- This PR fix issue [#1160 ](https://github.com/near/near-sdk-rs/issues/1160)from [near-sdk ]( https://github.com/near/near-sdk-rs/)

- Need to add the `exact_amount_display` method to format `yoctoNEAR` values for clearer error messages in `near-sdk` storage management.

### Implementation 

- Added `exact_amount_display` Method: it formats NearToken amounts for display as yoctoNEAR or NEAR.
- Based on [exact-display implementation from near-cli-rs](https://github.com/near/near-cli-rs/blob/7fca81bb5544b40743290d3a951c1f1ff31a95d9/src/types/near_token.rs#L18-L35) 
- Added tests for various cases: zero value, small values, exact NEAR values, and fractional NEAR values.

### Example Usage: 
```
let required_cost = NearToken::from_yoctonear(15 * 10_u128.pow(23));
format!("Must attach {} to cover storage", required_cost.exact_amount_display())
```
