### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/near/near-token-rs/compare/v0.2.0...v0.2.1) - 2024-07-31
+
+### Added
+- Added a new method `exact_amount_display` ([#9](https://github.com/near/near-token-rs/pull/9))
+
 ## [0.2.0](https://github.com/near/near-token-rs/compare/v0.1.0...v0.2.0) - 2023-10-28
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-token"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Serhieiev Ivan <serhieievivan6@gmail.com>", "Vlad Frolov <frolvlad@gmail.com>"]
 repository = "https://github.com/near/near-token"


### PR DESCRIPTION
## 🤖 New release
* `near-token`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/near/near-token-rs/compare/v0.2.0...v0.2.1) - 2024-07-31

### Added
- Added a new method `exact_amount_display` ([#9](https://github.com/near/near-token-rs/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).