### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/near/near-token-rs/compare/v0.2.1...v0.2.2) - 2024-08-12
+
+### Other
+- Extended the range of supported interactive-clap versions ([#11](https://github.com/near/near-token-rs/pull/11))
+
 ## [0.2.1](https://github.com/near/near-token-rs/compare/v0.2.0...v0.2.1) - 2024-07-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-token"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-token`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/near/near-token-rs/compare/v0.2.1...v0.2.2) - 2024-08-12

### Other
- Extended the range of supported interactive-clap versions ([#11](https://github.com/near/near-token-rs/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).