### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/near/near-token-rs/compare/v0.3.0...v0.3.1) - 2025-09-05
+
+### Added
+
+- Added support for schemars v1 ([#14](https://github.com/near/near-token-rs/pull/14))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for schemars v1 ([#14](https://github.com/near/near-token-rs/pull/14))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.3.0](https://github.com/near/near-token-rs/compare/v0.2.1...v0.3.0) - 2024-08-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-token"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-token`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).